### PR TITLE
팀원들 커밋 및 푸시 안됨 문제 - 해결완료

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eleven-pp"
-version = "0.0.0"
+version = "1.0.0"
 description = "The team-eleven's first pypi project. We make several functions for our work"
 authors = [
     {name = "team-eleven", email = "dlsrbs98@gmail.com"},


### PR DESCRIPTION
팀원들 각자 branch에서 커밋 및 푸시가 되지 않아

문제점을 찾고자 확인한 내용

### 해결

- organization 계정에 등록된 멤버들의 role을 **Member -> Owner 변경**

- 커밋 및 푸시 잘 됨.